### PR TITLE
Add support for patching nkit files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ care just hit enter and let it modify the file. If you are particularly concerne
 good dump ISO, consider creating a copy of it to be modified instead and use that with Six Patches
 of Pain.
 
+### Why Can I Not Use Nkit
+
+Nkit ISOs are compressed versions of normal game ISOs. Six Patches of Pain expects a normal game ISO,
+and therefore the Nkit ISO must be converted to a normal game ISO.
+
 ### It says I'm already on the latest version but I want to reinstall it
 
 Open the `data` folder, delete the file named `current_version`, and restart Six Patches of Pain.

--- a/six_patches_of_pain.go
+++ b/six_patches_of_pain.go
@@ -373,9 +373,9 @@ func isGNT4(filePath string) bool {
 					// This is an Nkit ISO, but we currently use a "bad" ISO dump instead.
 					// The bad dump is superior as it pads with zeroes instead of random bytes.
 					// Confirm the user is okay with modifying their Nkit to be a bad dump.
-					fmt.Println("\nNkit ISOs cannot be patched. Therefore this auto updater must create a normal ISO from it.")
-					fmt.Println("Please press enter if you are okay with creating a new ISO file.")
-					fmt.Println("If you are not okay with creating a new ISO file, please exit this application.")
+					fmt.Println("\nNkit ISOs must be modified in order to be used for this auto updater.")
+					fmt.Println("Please press enter if you are okay with this nkit being covnerted to a normal ISO.")
+					fmt.Println("If you are not okay with this nkit being modified, please exit this application.")
 					fmt.Println("\nFor more information, see the following information:")
 					fmt.Println("https://github.com/NicholasMoser/Six-Patches-Of-Pain#why-can-i-not-use-nkit")
 					fmt.Println("\nPress enter to continue...")

--- a/six_patches_of_pain.go
+++ b/six_patches_of_pain.go
@@ -2,7 +2,8 @@
 package main
 
 import (
-    "context"
+	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -18,8 +19,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/Athkore/go-xdelta"
 	"github.com/cheggaaa/pb/v3"
-    "github.com/Athkore/go-xdelta"
 )
 
 // DATA folder for data files
@@ -68,12 +69,12 @@ func main() {
 	argParse()
 	verifyIntegrity()
 	gnt4Iso := getGNT4ISO()
-    var newVersion string
-    if argSpecificVersion {
-        newVersion = downloadSpecificVersion()
-    } else {
-        newVersion = downloadNewVersion()
-    }
+	var newVersion string
+	if argSpecificVersion {
+		newVersion = downloadSpecificVersion()
+	} else {
+		newVersion = downloadNewVersion()
+	}
 	outputIso := fmt.Sprintf("SCON4-%s.iso", newVersion)
 	patchGNT4(gnt4Iso, outputIso)
 	setCurrentVersion(newVersion)
@@ -85,25 +86,25 @@ func main() {
 
 // Parse the arguments
 func argParse() {
-	flag.StringVar(&argGitRepository,"r","","Specify git repository to download updates from as 'https://api.github.com/repos/{user}/{repository}/releases'")
-	flag.StringVar(&argISOPath,"p","","Specify path of the GNT4 ISO")
-  flag.BoolVar(&argSpecificVersion,"specific",false,"Select a specific version to download")
+	flag.StringVar(&argGitRepository, "r", "", "Specify git repository to download updates from as 'https://api.github.com/repos/{user}/{repository}/releases'")
+	flag.StringVar(&argISOPath, "p", "", "Specify path of the GNT4 ISO")
+	flag.BoolVar(&argSpecificVersion, "specific", false, "Select a specific version to download")
 	flag.Parse()
 }
 
 // Verify the integrity of the auto-updater and required files.
 func verifyIntegrity() {
-    // Create the data directory if it doesn't already exist
-    if !exists(DATA) {
-        err := os.Mkdir(DATA, 0755)
-        check(err)
-    }
-    if argGitRepository != "" {
-        GitRepository = argGitRepository
-    }
-    if argISOPath != "" {
-        GNT4ISO = argISOPath
-    }
+	// Create the data directory if it doesn't already exist
+	if !exists(DATA) {
+		err := os.Mkdir(DATA, 0755)
+		check(err)
+	}
+	if argGitRepository != "" {
+		GitRepository = argGitRepository
+	}
+	if argISOPath != "" {
+		GNT4ISO = argISOPath
+	}
 	// If git repository is not set, set it to the default release repository. If set, but different from argument, reset if saveConfig arg is set
 	if !exists(GitRepositoryFile) {
 		d1 := []byte(GitRepository)
@@ -166,11 +167,15 @@ func getGNT4ISO() string {
 			return err
 		}
 		if !info.IsDir() && isGNT4(path) {
+			// Found, stop searching by returning EOF
 			gnt4Iso = path
+			return io.EOF
 		}
 		return nil
 	})
-	check(err)
+	if err != io.EOF {
+		check(err)
+	}
 	if gnt4Iso != "" {
 		setGNT4ISOPath(gnt4Iso)
 		return gnt4Iso
@@ -285,17 +290,17 @@ func downloadSpecificVersion() string {
 		fmt.Println("No releases found at " + repo)
 		fail()
 	}
-    for i:=0; i<len(releases); i++ {
-        fmt.Println(i,": ",releases[i].(map[string]interface{})["name"].(string))
-    }
-    fmt.Print("Enter the number of the wished release: ")
+	for i := 0; i < len(releases); i++ {
+		fmt.Println(i, ": ", releases[i].(map[string]interface{})["name"].(string))
+	}
+	fmt.Print("Enter the number of the wished release: ")
 	var input int
 	fmt.Scanln(&input)
-    if input >= len(releases) {
-        input = len(releases) - 1
-    } else if input < 0 {
-        input = 0
-    }
+	if input >= len(releases) {
+		input = len(releases) - 1
+	} else if input < 0 {
+		input = 0
+	}
 	specificRelease := releases[input].(map[string]interface{})
 	specificVersion := specificRelease["name"].(string)
 	// Download the patch
@@ -315,29 +320,29 @@ func downloadSpecificVersion() string {
 
 // Patches the given GNT4 ISO to the output SCON4 ISO path using the downloaded patch.
 func patchGNT4(gnt4Iso string, scon4Iso string) {
-    fmt.Println("Patching GNT4...")
-    gnt4File, err := os.Open(gnt4Iso)
-    check(err)
-    scon4File, err := os.OpenFile(scon4Iso, os.O_WRONLY|os.O_CREATE, 0644)
-    check(err)
-    patchFile, err := os.Open(PatchFile)
-    check(err)
-    gnt4ReadSeeker := io.ReadSeeker(gnt4File)
-    scon4Writer := io.Writer(scon4File)
-    patchReader := io.Reader(patchFile)
+	fmt.Println("Patching GNT4...")
+	gnt4File, err := os.Open(gnt4Iso)
+	check(err)
+	scon4File, err := os.OpenFile(scon4Iso, os.O_WRONLY|os.O_CREATE, 0644)
+	check(err)
+	patchFile, err := os.Open(PatchFile)
+	check(err)
+	gnt4ReadSeeker := io.ReadSeeker(gnt4File)
+	scon4Writer := io.Writer(scon4File)
+	patchReader := io.Reader(patchFile)
 
-    options := xdelta.DecoderOptions{
-        FileID:     scon4Iso,
-        FromFile:   gnt4ReadSeeker,
-        ToFile:     scon4Writer,
-        PatchFile:  patchReader,
-        EnableStats:    true,
-    }
-    enc, err := xdelta.NewDecoder(options)
-    check(err)
-    defer enc.Close()
-    err = enc.Process(context.TODO())
-    check(err)
+	options := xdelta.DecoderOptions{
+		FileID:      scon4Iso,
+		FromFile:    gnt4ReadSeeker,
+		ToFile:      scon4Writer,
+		PatchFile:   patchReader,
+		EnableStats: true,
+	}
+	enc, err := xdelta.NewDecoder(options)
+	check(err)
+	defer enc.Close()
+	err = enc.Process(context.TODO())
+	check(err)
 
 	if exists(scon4Iso) && getFileSize(scon4Iso) > 0 {
 		isoFullPath, err := filepath.Abs(scon4Iso)
@@ -359,23 +364,43 @@ func isGNT4(filePath string) bool {
 		if reflect.DeepEqual(expected, data[:len]) {
 			fmt.Println("Validating GNT4 ISO is not modified...")
 			hashValue, err := hashFile(filePath)
+			fmt.Println(hashValue)
 			check(err)
+			// 60aefa3e is the CRC32 hash of both a good ISO dump AND an Nkit ISO somehow
+			// Check whether this file is an ISO or an Nkit
 			if hashValue == "60aefa3e" {
-				// 60aefa3e is the hash for a good dump, but we currently use a "bad" dump instead.
-				// The bad dump is superior as it pads with zeroes instead of random bytes.
-				// Confirm the user is okay with modifying their good dump to be a bad dump.
-				fmt.Println("\nThe vanilla ISO you provided must be modified in order to be used for this auto updater.")
-				fmt.Println("Please press enter if you are okay with this ISO being modified.")
-				fmt.Println("If you are not okay with this ISO being modified, please exit this application.")
-				fmt.Println("\nFor more information, see the following information:")
-				fmt.Println("https://github.com/NicholasMoser/Six-Patches-Of-Pain#why-does-it-say-my-vanilla-iso-needs-to-be-modified")
-				fmt.Println("\nPress enter to continue...")
-				var output string
-				fmt.Scanln(&output)
-				err = patchGoodDump(filePath)
-				fmt.Println("\nISO has been modified and is now valid.")
-				check(err)
-				return true
+				if isNkit(filePath) {
+					// This is an Nkit ISO, but we currently use a "bad" ISO dump instead.
+					// The bad dump is superior as it pads with zeroes instead of random bytes.
+					// Confirm the user is okay with modifying their Nkit to be a bad dump.
+					fmt.Println("\nNkit ISOs cannot be patched. Therefore this auto updater must create a normal ISO from it.")
+					fmt.Println("Please press enter if you are okay with creating a new ISO file.")
+					fmt.Println("If you are not okay with creating a new ISO file, please exit this application.")
+					fmt.Println("\nFor more information, see the following information:")
+					fmt.Println("https://github.com/NicholasMoser/Six-Patches-Of-Pain#why-can-i-not-use-nkit")
+					fmt.Println("\nPress enter to continue...")
+					var output string
+					fmt.Scanln(&output)
+					convertNkitToIso(filePath)
+					fmt.Println("\nISO has been created and is now valid.")
+					return true
+				} else {
+					// This is a good ISO dump, but we currently use a "bad" dump instead.
+					// The bad dump is superior as it pads with zeroes instead of random bytes.
+					// Confirm the user is okay with modifying their good dump to be a bad dump.
+					fmt.Println("\nThe vanilla ISO you provided must be modified in order to be used for this auto updater.")
+					fmt.Println("Please press enter if you are okay with this ISO being modified.")
+					fmt.Println("If you are not okay with this ISO being modified, please exit this application.")
+					fmt.Println("\nFor more information, see the following information:")
+					fmt.Println("https://github.com/NicholasMoser/Six-Patches-Of-Pain#why-does-it-say-my-vanilla-iso-needs-to-be-modified")
+					fmt.Println("\nPress enter to continue...")
+					var output string
+					fmt.Scanln(&output)
+					err = patchGoodDump(filePath)
+					fmt.Println("\nISO has been modified and is now valid.")
+					check(err)
+					return true
+				}
 			}
 			return hashValue == "55ee8b1a"
 		}
@@ -415,6 +440,108 @@ func patchGoodDump(filePath string) error {
 	// Just add 11108 zeroes directly.
 	_, err = file.WriteAt(evenMoreZeroes[:], 0x4553001C)
 	return err
+}
+
+// Check if an ISO is an nkit ISO
+func isNkit(input string) bool {
+	in, err := os.OpenFile(input, os.O_RDONLY, 0644)
+	check(err)
+	defer in.Close()
+	bytes := make([]byte, 0x4)
+	_, err = in.ReadAt(bytes, 0x200)
+	check(err)
+	return reflect.DeepEqual(bytes, []byte{0x4E, 0x4B, 0x49, 0x54}) // NKIT
+}
+
+// Convert a GNT4 nkit.iso file to a GNT4 iso file
+func convertNkitToIso(input string) {
+	fmt.Println("Converting GNT4 nkit to iso...")
+
+	// Create temp file
+	temp, err := os.CreateTemp("", "example")
+	check(err)
+	defer os.Remove(temp.Name())
+	fmt.Println(temp.Name())
+
+	// Read sys bytes
+	in, err := os.OpenFile(input, os.O_RDWR, 0644)
+	check(err)
+	sys := make([]byte, 0x2480F0)
+	_, err = in.Read(sys)
+	check(err)
+
+	// Write sys bytes
+	_, err = temp.Write(sys)
+	check(err)
+
+	// Fix sys bytes
+	_, err = temp.WriteAt(make([]byte, 0x14), 0x200)
+	check(err)
+	_, err = temp.WriteAt([]byte{0x00, 0x52, 0x02, 0x02}, 0x500)
+	check(err)
+
+	// Fix file system table (fst.bin)
+	skip := []int64{0x245250, 0x24525C, 0x24612C, 0x2462B8, 0x246660, 0x246720}
+	for i := int64(0x244D28); i < 0x246760; i += 0xC {
+		if !contains(skip, i) {
+			buf := make([]byte, 0x4)
+			_, err := in.ReadAt(buf, i)
+			check(err)
+			offset := binary.BigEndian.Uint32(buf)
+			new_offset := offset + 0xC2A8000
+			if i >= 0x245268 {
+				new_offset += 0x2B7C
+			}
+			binary.BigEndian.PutUint32(buf, new_offset)
+			_, err = temp.WriteAt(buf, i)
+			check(err)
+		}
+	}
+	_, err = temp.WriteAt(make([]byte, 0x4), 0x2480E8)
+
+	// Copy the rest of the files over
+	buf_size := 0x4096
+	buf := make([]byte, buf_size)
+	i := int64(0x250000)
+	offset := int64(0xC2A8000)
+	iterations := 0x4AB5D800 / buf_size
+	bar := pb.StartNew(iterations)
+	for {
+		num, err1 := in.ReadAt(buf, i)
+		// Need to write out bytes before EOF check since you can have both EOF and bytes read
+		if num > 0 {
+			if num != buf_size {
+				// Resize buffer to print last bytes minus padding at end of nkit
+				buf = buf[:num-0x37C]
+			}
+			_, err2 := temp.WriteAt(buf, i+offset)
+			check(err2)
+		}
+		if errors.Is(err1, io.EOF) {
+			break
+		}
+		if i == 0x39282912 {
+			// The GNT4 ISO has extra spacing after some files here, so account for that
+			offset += 0x2B7C
+		}
+		i += int64(buf_size)
+		bar.Increment()
+	}
+	bar.Finish()
+
+	// Last little bit of cleanup
+	_, err = temp.WriteAt(make([]byte, 0x2), 0x45532B7E)
+	check(err)
+
+	// Copy temp file to nkit
+	temp.Seek(0, 0)
+	in.Seek(0, 0)
+	fmt.Println("Copying temp output back to nkit...")
+	bar2 := pb.Full.Start64(0x57058000)
+	defer bar2.Finish()
+	barReader := bar2.NewProxyReader(temp)
+	_, err = io.Copy(in, barReader)
+	check(err)
 }
 
 // Download to a file path the file at the given url.
@@ -511,6 +638,16 @@ func getFileSize(filePath string) int64 {
 func exists(path string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true
+	}
+	return false
+}
+
+// Return whether or not an array of int64 contains an int64
+func contains(s []int64, val int64) bool {
+	for _, v := range s {
+		if v == val {
+			return true
+		}
 	}
 	return false
 }

--- a/test/nkit2iso.go
+++ b/test/nkit2iso.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/cheggaaa/pb/v3"
 )
 
 // Test converting a GNT4 nkit to iso
@@ -57,8 +59,8 @@ func main() {
 	buf := make([]byte, buf_size)
 	i := int64(0x250000)
 	offset := int64(0xC2A8000)
-	//iterations := 0x4AB5D800 / buf_size
-	//bar := pb.StartNew(iterations)
+	iterations := 0x4AB5D800 / buf_size
+	bar := pb.StartNew(iterations)
 	for {
 		num, err1 := in.ReadAt(buf, i)
 		// Need to write out bytes before EOF check since you can have both EOF and bytes read
@@ -78,9 +80,9 @@ func main() {
 			offset += 0x2B7C
 		}
 		i += int64(buf_size)
-		//bar.Increment()
+		bar.Increment()
 	}
-	//bar.Finish()
+	bar.Finish()
 
 	// Last little bit of cleanup
 	_, err = out.WriteAt(make([]byte, 0x2), 0x45532B7E)

--- a/test/nkit2iso.go
+++ b/test/nkit2iso.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Test converting a GNT4 nkit to iso
+func main() {
+	fmt.Println("Converting GNT4 nkit to iso...")
+
+	// Read sys bytes
+	in, err := os.OpenFile("../GNT4.nkit.iso", os.O_RDONLY, 0644)
+	check(err)
+	defer in.Close()
+	sys := make([]byte, 0x2480F0)
+	_, err = in.Read(sys)
+	check(err)
+
+	// Write sys bytes
+	out, err := os.Create("../test.iso")
+	check(err)
+	defer out.Close()
+	_, err = out.Write(sys)
+	check(err)
+
+	// Fix sys bytes
+	_, err = out.WriteAt(make([]byte, 0x14), 0x200)
+	check(err)
+	_, err = out.WriteAt([]byte{0x00, 0x52, 0x02, 0x02}, 0x500)
+	check(err)
+
+	// Fix file system table (fst.bin)
+	skip := []int64{0x245250, 0x24525C, 0x24612C, 0x2462B8, 0x246660, 0x246720}
+	for i := int64(0x244D28); i < 0x246760; i += 0xC {
+		if !contains(skip, i) {
+			buf := make([]byte, 0x4)
+			_, err := in.ReadAt(buf, i)
+			check(err)
+			offset := binary.BigEndian.Uint32(buf)
+			new_offset := offset + 0xC2A8000
+			if i >= 0x245268 {
+				new_offset += 0x2B7C
+			}
+			binary.BigEndian.PutUint32(buf, new_offset)
+			_, err = out.WriteAt(buf, i)
+			check(err)
+		}
+	}
+	_, err = out.WriteAt(make([]byte, 0x4), 0x2480E8)
+
+	// Copy the rest of the files over
+	buf_size := 0x4096
+	buf := make([]byte, buf_size)
+	i := int64(0x250000)
+	offset := int64(0xC2A8000)
+	//iterations := 0x4AB5D800 / buf_size
+	//bar := pb.StartNew(iterations)
+	for {
+		num, err1 := in.ReadAt(buf, i)
+		// Need to write out bytes before EOF check since you can have both EOF and bytes read
+		if num > 0 {
+			if num != buf_size {
+				// Resize buffer to print last bytes minus padding at end of nkit
+				buf = buf[:num-0x37C]
+			}
+			_, err2 := out.WriteAt(buf, i+offset)
+			check(err2)
+		}
+		if errors.Is(err1, io.EOF) {
+			break
+		}
+		if i == 0x39282912 {
+			// The GNT4 ISO has extra spacing after some files here, so account for that
+			offset += 0x2B7C
+		}
+		i += int64(buf_size)
+		//bar.Increment()
+	}
+	//bar.Finish()
+
+	// Last little bit of cleanup
+	_, err = out.WriteAt(make([]byte, 0x2), 0x45532B7E)
+	check(err)
+
+}
+
+func contains(s []int64, val int64) bool {
+	for _, v := range s {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/NicholasMoser/Six-Patches-Of-Pain/issues/5

This PR will convert an nkit ISO to a normal ISO that can be patched. It first writes the converted ISO bytes to a temporary file and then copies the temporary file back to the nkit ISO. This means that the nkit ISO will be overriden and become a normal ISO.

I recommend disabling whitespace changes for this PR
![image](https://user-images.githubusercontent.com/4983605/190880169-5734d6ab-ad0f-4230-adbf-fb5ad9c156dc.png)
